### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Create events in macOS calendar from OmniFocus tasks
 
 ---
 
+### Usage
+
+This script can be run from the command line with two optional parameters:
+1. The number of days to look ahead (default is 1)
+2. The number of days to look back (default is 1)
+
+Example: `osascript omnifocus_tasks_to_calendar.scpt 30 7`
+
+---
+
 ### Overview
 
 For the sake of making things more complicated than it has to be, the calendars that are synced to are deleted each time the script runs, thus requiring an individual calendar(s) specifically for it. DO NOT USE A PRIMARY CALENDAR! It was a lot easier to tell a calendar to delete all of its events than compare existing events and update them when needed. In accordance with the runtime of the script, my Mac mini M4 does a week's worth of tasks to calendar events in about 30 seconds, while my 2019 Intel MacBook Pro can take 3 to 4 times longer (but I don't sync from it anymore).

--- a/omnifocus_tasks_to_calendar.scpt
+++ b/omnifocus_tasks_to_calendar.scpt
@@ -25,24 +25,26 @@ property default_event_duration : 30  --in minutes
 
 on run argv
 
-	-- Set numOfDaysToInclude to 1 if not passed in
+	-- Set daysAhead to 1 if not passed in
 	if (count of argv) > 0 then
-		set numOfDaysToInclude to item 1 of argv as integer
+		set daysAhead to item 1 of argv as integer
+		set daysBack to item 2 of argv as integer
 	else
-		set numOfDaysToInclude to 1
+		set daysAhead to 1
+		set daysBack to 1
 	end if
 
 	-- Create global variables
 	set calendar_element to missing value  --initialize to null
 
 	-- for the days to pull tasks from, set the start date to today's date at the prior midnight
-	set theStartDate to current date - (days * 30)
+	set theStartDate to current date - (days * daysBack)
 	set hours of theStartDate to 0
 	set minutes of theStartDate to 0
 	set seconds of theStartDate to 0
 
 	-- for the days to pull tasks from, set the end date to today's date plus how many days to look forward
-	set theEndDate to current date + (days * (numOfDaysToInclude - 1))
+	set theEndDate to current date + (days * (daysAhead - 1))
 	set hours of theEndDate to 23
 	set minutes of theEndDate to 59
 	set seconds of theEndDate to 59

--- a/omnifocus_tasks_to_calendar.scpt
+++ b/omnifocus_tasks_to_calendar.scpt
@@ -57,9 +57,9 @@ on run argv
 
 	-- Check if the current time is 4 am
 	set currentHour to hours of (current date)
-	if currentHour is not 4 then
+	-- if currentHour is not 4 then
 		-- do nothing --
-	else
+	-- else
 		-- Restart the Calendar app minimized
 		tell application "Calendar" to quit
 		delay 1
@@ -67,7 +67,7 @@ on run argv
 			activate
 			set miniaturized of every window to true
 		end tell
-	end if
+	-- end if
 
 	-- ********************************* --
 	-- CALL THE HANDLERS WITH PARAMETERS --

--- a/omnifocus_tasks_to_calendar.scpt
+++ b/omnifocus_tasks_to_calendar.scpt
@@ -15,6 +15,15 @@
 -- -- -- refactored script to use handlers (2024-08-19)
 -- -- -- make the calendar alert align with task's due date
 -- -- -- refactor the script for only one processing tasks handler (2025-02-20)
+-- -- -- add back to make the calendar app minimized when the script runs (2025-05-30)
+-- -- -- added how to run the script via Usage comments (2025-05-30)
+
+
+-- ** USAGE ** --
+-- This script can be run from the command line with two optional parameters:
+-- 1. The number of days to look ahead (default is 1)
+-- 2. The number of days to look back (default is 1)
+-- Example: `osascript omnifocus_tasks_to_calendar.scpt 30 7`
 
 
 -- ******** --
@@ -26,6 +35,7 @@ property default_event_duration : 30  --in minutes
 on run argv
 
 	-- Set daysAhead to 1 if not passed in
+	-- Set daysBack to 1 if not passed in
 	if (count of argv) > 0 then
 		set daysAhead to item 1 of argv as integer
 		set daysBack to item 2 of argv as integer

--- a/omnifocus_tasks_to_calendar.scpt
+++ b/omnifocus_tasks_to_calendar.scpt
@@ -36,7 +36,7 @@ on run argv
 	set calendar_element to missing value  --initialize to null
 
 	-- for the days to pull tasks from, set the start date to today's date at the prior midnight
-	set theStartDate to current date
+	set theStartDate to current date - (days * 30)
 	set hours of theStartDate to 0
 	set minutes of theStartDate to 0
 	set seconds of theStartDate to 0


### PR DESCRIPTION
- add two parameters (daysAhead, daysBack)
- revert to restarting the Calendar app to prevent script failing in launchd, thus preventing future runs without intervention
- add Usage sections to README and script header comments